### PR TITLE
Fixed bug in CalculateDay()

### DIFF
--- a/ADPermittedLogonTime/PermittedLogonTimes.cs
+++ b/ADPermittedLogonTime/PermittedLogonTimes.cs
@@ -304,7 +304,7 @@ namespace ADPermittedLogonTime
 
         private static DayOfWeek CalculateDay(int index, int offset)
         {
-            var day = Math.Floor((decimal)(index + offset)/7);
+            var day = Math.Floor((decimal)(index + offset)/24);
             
             return (DayOfWeek) day;
         }


### PR DESCRIPTION
Using PermittedLogonTimes.GetLogonTimes() I was getting strange results for the DayOfWeek properties of the resulting LogonTimes.

Stepping through the code it seems that CalculateDay() was incorrectly dividing the index by 7 days instead of 24 hours.

Changing this seems to work for me, although I will admit I haven't done extensive testing on the impact of the change.
